### PR TITLE
feat(deps): update dependency `typedoc` to `0.23.8`

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,9 @@
   "dependencies": {
     "@favware/colorette-spinner": "^1.0.0",
     "colorette": "^2.0.19",
-    "commander": "^9.3.0",
+    "commander": "^9.4.0",
     "js-yaml": "^4.1.0",
-    "typedoc": "^0.23.6"
+    "typedoc": "^0.23.8"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "colorette": "^2.0.19",
     "commander": "^9.3.0",
     "js-yaml": "^4.1.0",
-    "typedoc": "^0.22.18"
+    "typedoc": "^0.23.6"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.0.3",

--- a/src/lib/structures/ConstantParser.ts
+++ b/src/lib/structures/ConstantParser.ts
@@ -60,7 +60,7 @@ export class ConstantParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): ConstantParser {
-    const { kind, kindString = 'Unknown', id, name, comment = {}, sources = [], flags, type, defaultValue } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], flags, type, defaultValue } = reflection;
 
     if (kind !== ReflectionKind.Variable) throw new Error(`Expected Variable (${ReflectionKind.Variable}), but received ${kindString} (${kind})`);
 

--- a/src/lib/structures/FunctionParser.ts
+++ b/src/lib/structures/FunctionParser.ts
@@ -51,7 +51,7 @@ export class FunctionParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): FunctionParser {
-    const { kind, kindString = 'Unknown', id, name, comment = {}, sources = [], flags, signatures = [] } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], flags, signatures = [] } = reflection;
 
     if (kind !== ReflectionKind.Function) throw new Error(`Expected Function (${ReflectionKind.Function}), but received ${kindString} (${kind})`);
 

--- a/src/lib/structures/NamespaceParser.ts
+++ b/src/lib/structures/NamespaceParser.ts
@@ -105,7 +105,7 @@ export class NamespaceParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): NamespaceParser {
-    const { kind, kindString = 'Unknown', id, name, comment = {}, sources = [], flags, children = [] } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], flags, children = [] } = reflection;
 
     if (kind !== ReflectionKind.Namespace) throw new Error(`Expected Namespace (${ReflectionKind.Namespace}), but received ${kindString} (${kind})`);
 

--- a/src/lib/structures/TypeAliasParser.ts
+++ b/src/lib/structures/TypeAliasParser.ts
@@ -60,7 +60,7 @@ export class TypeAliasParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): TypeAliasParser {
-    const { kind, kindString = 'Unknown', id, name, comment = {}, sources = [], flags, type, typeParameter: typeParameters = [] } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], flags, type, typeParameters = [] } = reflection;
 
     if (kind !== ReflectionKind.TypeAlias) throw new Error(`Expected TypeAlias (${ReflectionKind.TypeAlias}), but received ${kindString} (${kind})`);
 

--- a/src/lib/structures/class-parser/ClassConstructorParser.ts
+++ b/src/lib/structures/class-parser/ClassConstructorParser.ts
@@ -39,7 +39,7 @@ export class ClassConstructorParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): ClassConstructorParser {
-    const { kind, kindString = 'Unknown', id, name, comment = {}, sources = [], signatures = [] } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], signatures = [] } = reflection;
 
     if (kind !== ReflectionKind.Constructor) {
       throw new Error(`Expected Constructor (${ReflectionKind.Constructor}), but received ${kindString} (${kind})`);

--- a/src/lib/structures/class-parser/ClassMethodParser.ts
+++ b/src/lib/structures/class-parser/ClassMethodParser.ts
@@ -68,7 +68,7 @@ export class ClassMethodParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): ClassMethodParser {
-    const { kind, kindString = 'Unknown', id, name, comment = {}, sources = [], flags, signatures = [] } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], flags, signatures = [] } = reflection;
 
     if (kind !== ReflectionKind.Method) throw new Error(`Expected Method (${ReflectionKind.Method}), but received ${kindString} (${kind})`);
 

--- a/src/lib/structures/class-parser/ClassParser.ts
+++ b/src/lib/structures/class-parser/ClassParser.ts
@@ -100,7 +100,7 @@ export class ClassParser extends Parser {
       kindString = 'Unknown',
       id,
       name,
-      comment = {},
+      comment = { summary: [] },
       sources = [],
       flags,
       children = [],

--- a/src/lib/structures/class-parser/ClassPropertyParser.ts
+++ b/src/lib/structures/class-parser/ClassPropertyParser.ts
@@ -85,7 +85,7 @@ export class ClassPropertyParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): ClassPropertyParser {
-    const { kind, kindString = 'Unknown', id, name, comment = {}, sources = [], type, flags } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], type, flags, getSignature } = reflection;
 
     if (kind !== ReflectionKind.Property && kind !== ReflectionKind.Accessor) {
       throw new Error(
@@ -94,11 +94,9 @@ export class ClassPropertyParser extends Parser {
     }
 
     if (kind === ReflectionKind.Accessor) {
-      const [getter] = reflection.getSignature ?? [];
+      if (getSignature === undefined) throw new Error(`Expected Accessor (${ReflectionKind.Accessor}) with a getter, but there was none`);
 
-      if (getter === undefined) throw new Error(`Expected Accessor (${ReflectionKind.Accessor}) with a getter, but there was none`);
-
-      const { id, name, comment = {}, type, flags } = getter;
+      const { id, name, comment = { summary: [] }, type, flags } = getSignature;
 
       return new ClassPropertyParser(
         {

--- a/src/lib/structures/enum-parser/EnumParser.ts
+++ b/src/lib/structures/enum-parser/EnumParser.ts
@@ -52,7 +52,7 @@ export class EnumParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): EnumParser {
-    const { kind, kindString = 'Unknown', id, name, comment = {}, sources = [], flags, children = [] } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], flags, children = [] } = reflection;
 
     if (kind !== ReflectionKind.Enum) throw new Error(`Expected Enum (${ReflectionKind.Enum}), but received ${kindString} (${kind})`);
 

--- a/src/lib/structures/enum-parser/EnumPropertyParser.ts
+++ b/src/lib/structures/enum-parser/EnumPropertyParser.ts
@@ -3,6 +3,7 @@ import { ReflectionKind } from '../../types';
 import { CommentParser, SourceParser } from '../misc';
 import { Parser } from '../Parser';
 import type { ProjectParser } from '../ProjectParser';
+import { TypeParser } from '../type-parsers';
 
 /**
  * Parses data from an enum property reflection.
@@ -43,7 +44,7 @@ export class EnumPropertyParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): EnumPropertyParser {
-    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], defaultValue } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], type } = reflection;
 
     if (kind !== ReflectionKind.EnumMember) {
       throw new Error(`Expected EnumMember (${ReflectionKind.EnumMember}), but received ${kindString} (${kind})`);
@@ -55,7 +56,7 @@ export class EnumPropertyParser extends Parser {
         name,
         comment: CommentParser.generateFromTypeDoc(comment, project),
         source: sources.length ? SourceParser.generateFromTypeDoc(sources[0], project) : null,
-        value: defaultValue!
+        value: TypeParser.generateFromTypeDoc(type!).toString()
       },
       project
     );

--- a/src/lib/structures/enum-parser/EnumPropertyParser.ts
+++ b/src/lib/structures/enum-parser/EnumPropertyParser.ts
@@ -43,7 +43,7 @@ export class EnumPropertyParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): EnumPropertyParser {
-    const { kind, kindString = 'Unknown', id, name, comment = {}, sources = [], defaultValue } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], defaultValue } = reflection;
 
     if (kind !== ReflectionKind.EnumMember) {
       throw new Error(`Expected EnumMember (${ReflectionKind.EnumMember}), but received ${kindString} (${kind})`);

--- a/src/lib/structures/interface-parser/InterfaceParser.ts
+++ b/src/lib/structures/interface-parser/InterfaceParser.ts
@@ -52,7 +52,7 @@ export class InterfaceParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): InterfaceParser {
-    const { kind, kindString = 'Unknown', id, name, comment = {}, sources = [], flags, children = [] } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], flags, children = [] } = reflection;
 
     if (kind !== ReflectionKind.Interface) throw new Error(`Expected Interface (${ReflectionKind.Interface}), but received ${kindString} (${kind})`);
 

--- a/src/lib/structures/interface-parser/InterfacePropertyParser.ts
+++ b/src/lib/structures/interface-parser/InterfacePropertyParser.ts
@@ -52,7 +52,7 @@ export class InterfacePropertyParser extends Parser {
    * @returns The generated parser.
    */
   public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): InterfacePropertyParser {
-    const { kind, kindString = 'Unknown', id, name, comment = {}, sources = [], type, flags } = reflection;
+    const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], type, flags } = reflection;
 
     if (kind !== ReflectionKind.Property) throw new Error(`Expected Property (${ReflectionKind.Property}), but received ${kindString} (${kind})`);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3293,7 +3293,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"glob@npm:^8.0.1, glob@npm:^8.0.3":
+"glob@npm:^8.0.1":
   version: 8.0.3
   resolution: "glob@npm:8.0.3"
   dependencies:
@@ -6223,27 +6223,26 @@ __metadata:
     pretty-quick: ^3.1.3
     rimraf: ^3.0.2
     ts-jest: ^28.0.5
-    typedoc: ^0.22.18
+    typedoc: ^0.23.6
     typescript: ^4.7.4
   bin:
     typedoc-json-parser: ./dist/bin/index.js
   languageName: unknown
   linkType: soft
 
-"typedoc@npm:^0.22.18":
-  version: 0.22.18
-  resolution: "typedoc@npm:0.22.18"
+"typedoc@npm:^0.23.6":
+  version: 0.23.6
+  resolution: "typedoc@npm:0.23.6"
   dependencies:
-    glob: ^8.0.3
     lunr: ^2.3.9
     marked: ^4.0.16
     minimatch: ^5.1.0
     shiki: ^0.10.1
   peerDependencies:
-    typescript: 4.0.x || 4.1.x || 4.2.x || 4.3.x || 4.4.x || 4.5.x || 4.6.x || 4.7.x
+    typescript: 4.6.x || 4.7.x
   bin:
     typedoc: bin/typedoc
-  checksum: b813d8129682f6ed5a4e96bacaf019e4da1d2744ca89fef850d6bb4c034616567ce67e6a7f5cfc5f00aac573f0b45d44b1427aafa262ab88dce6b460cb9e744c
+  checksum: 74db2eedec4af4764b182d83f7d9ba20f934b7b1ff989de72f104cf173baeca90221e044c3229e7f2df58590078ead3fc5eca3b0088214e588d9d1da0b85ee58
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2327,6 +2327,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"commander@npm:^9.4.0":
+  version: 9.4.0
+  resolution: "commander@npm:9.4.0"
+  checksum: a322de584a6ccd1ea83c24f6a660e52d16ffbe2613fcfbb8d2cc68bc9dec637492456d754fe8bb5b039ad843ed8e04fb0b107e581a75f62cde9e1a0ab1546e09
+  languageName: node
+  linkType: hard
+
 "compare-func@npm:^2.0.0":
   version: 2.0.0
   resolution: "compare-func@npm:2.0.0"
@@ -6208,7 +6215,7 @@ __metadata:
     "@typescript-eslint/eslint-plugin": ^5.29.0
     "@typescript-eslint/parser": ^5.29.0
     colorette: ^2.0.19
-    commander: ^9.3.0
+    commander: ^9.4.0
     eslint: ^8.18.0
     eslint-config-prettier: ^8.5.0
     eslint-plugin-prettier: ^4.0.0
@@ -6223,16 +6230,16 @@ __metadata:
     pretty-quick: ^3.1.3
     rimraf: ^3.0.2
     ts-jest: ^28.0.5
-    typedoc: ^0.23.6
+    typedoc: ^0.23.8
     typescript: ^4.7.4
   bin:
     typedoc-json-parser: ./dist/bin/index.js
   languageName: unknown
   linkType: soft
 
-"typedoc@npm:^0.23.6":
-  version: 0.23.6
-  resolution: "typedoc@npm:0.23.6"
+"typedoc@npm:^0.23.8":
+  version: 0.23.8
+  resolution: "typedoc@npm:0.23.8"
   dependencies:
     lunr: ^2.3.9
     marked: ^4.0.16
@@ -6242,7 +6249,7 @@ __metadata:
     typescript: 4.6.x || 4.7.x
   bin:
     typedoc: bin/typedoc
-  checksum: 74db2eedec4af4764b182d83f7d9ba20f934b7b1ff989de72f104cf173baeca90221e044c3229e7f2df58590078ead3fc5eca3b0088214e588d9d1da0b85ee58
+  checksum: 99568e5df15781def0761d9876a86883bb58cb5318c258be965628626cc33737cd605640de2a9397f6722bccaed70aeb1e68c5f390b03ac7e8a17da9f091f906
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<details><summary>

## Commit Body

</summary>

BREAKING CHANGES

- The `typedoc` dependency has been updated to `0.23.8`
- The `CommentParser#tags` property has been removed along with `#tags` in related interfaces. See `#blockTags` and `#modifierTags` instead.
- The `CommentParser#extendedDescription` has been removed and merged with `#description` along with related interfaces.
</details>