### PR TITLE
refactor(CommentParser): format `inline-tag`

### DIFF
--- a/src/lib/structures/misc/CommentParser.ts
+++ b/src/lib/structures/misc/CommentParser.ts
@@ -89,11 +89,11 @@ export class CommentParser {
     return new CommentParser(
       {
         description: summary.length
-          ? summary.map((summary) => (summary.kind === 'inline-tag' ? `{${summary.tag} ${summary.text}}` : summary.text)).join('\n')
+          ? summary.map((summary) => (summary.kind === 'inline-tag' ? `{${summary.tag} ${summary.text}}` : summary.text)).join('')
           : null,
         blockTags: blockTags.map((tag) => ({
           name: tag.name ?? tag.tag.replace(/@/, ''),
-          text: tag.content.map((content) => (content.kind === 'inline-tag' ? `{${content.tag} ${content.text}}` : content.text)).join('\n')
+          text: tag.content.map((content) => (content.kind === 'inline-tag' ? `{${content.tag} ${content.text}}` : content.text)).join('')
         })),
         modifierTags
       },

--- a/src/lib/structures/misc/CommentParser.ts
+++ b/src/lib/structures/misc/CommentParser.ts
@@ -88,10 +88,12 @@ export class CommentParser {
 
     return new CommentParser(
       {
-        description: summary.length ? summary.map((summary) => summary.text).join('\n') : null,
+        description: summary.length
+          ? summary.map((summary) => (summary.kind === 'inline-tag' ? `{${summary.tag} ${summary.text}}` : summary.text)).join('\n')
+          : null,
         blockTags: blockTags.map((tag) => ({
           name: tag.name ?? tag.tag.replace(/@/, ''),
-          text: tag.content.map((content) => content.text).join('\n')
+          text: tag.content.map((content) => (content.kind === 'inline-tag' ? `{${content.tag} ${content.text}}` : content.text)).join('\n')
         })),
         modifierTags
       },


### PR DESCRIPTION
`CommentParser#description` and `CommentParser#blockTags` now format `inline-tag`

### Before

```json
"Generates a new TypeParameterParser instance from the given data."
```

### After

```json
"Generates a new {@link TypeParameterParser} instance from the given data."
```

## Commit Body

```
BREAKING CHANGE: `CommentParser#description` now formats `inline-tag`
BREAKING CHANGE: `CommentParser#blockTags` now formats `inline-tag`
```