### PR TITLE
feat(ProjectParser): add `readme` property

### DIFF
--- a/src/bin/commands/parse-docs.ts
+++ b/src/bin/commands/parse-docs.ts
@@ -1,4 +1,5 @@
 import { Spinner } from '@favware/colorette-spinner';
+import { existsSync } from 'node:fs';
 import { readFile, writeFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import type { JSONOutput } from 'typedoc';
@@ -7,9 +8,10 @@ import type { Options } from '../lib/types/Options';
 
 export async function parseDocs(options: Options) {
   const spinner = new Spinner().start({ text: 'Parsing TypeDoc JSON output' });
-  const packageJson = JSON.parse(await readFile(resolve(process.cwd(), 'package.json'), 'utf8'));
-  const project = JSON.parse(await readFile(resolve(process.cwd(), options.json), 'utf-8')) as JSONOutput.ProjectReflection;
-  const parsed = new ProjectParser(project, packageJson.version).toJSON();
+  const { version } = JSON.parse(await readFile(resolve(process.cwd(), 'package.json'), 'utf8'));
+  const readme = existsSync(resolve(process.cwd(), 'README.md')) ? await readFile(resolve(process.cwd(), 'README.md'), 'utf8') : undefined;
+  const data = JSON.parse(await readFile(resolve(process.cwd(), options.json), 'utf-8')) as JSONOutput.ProjectReflection;
+  const parsed = new ProjectParser({ data, version, readme }).toJSON();
 
   try {
     await writeFile(resolve(process.cwd(), options.json), JSON.stringify(parsed, null, 2));

--- a/src/lib/structures/ProjectParser.ts
+++ b/src/lib/structures/ProjectParser.ts
@@ -42,6 +42,12 @@ export class ProjectParser {
   public readonly version: string | null = null;
 
   /**
+   * The readme content of this project.
+   * @since 3.0.0
+   */
+  public readonly readme: string | null = null;
+
+  /**
    * An array of class parsers for this project.
    * @since 1.0.0
    */
@@ -83,11 +89,13 @@ export class ProjectParser {
    */
   public readonly typeAliases: TypeAliasParser[];
 
-  public constructor(data: ProjectParser.JSON | JSONOutput.ProjectReflection, version: string | null = null) {
+  public constructor(options: ProjectParser.Options) {
+    const { data, version, readme } = options;
     const { id, name } = data;
 
     this.id = id;
     this.name = name;
+    this.readme = readme ?? null;
 
     if ('classes' in data) {
       const { typeDocJsonParserVersion, classes, constants, enums, functions, interfaces, namespaces, typeAliases } = data;
@@ -106,7 +114,7 @@ export class ProjectParser {
 
       if (kind !== ReflectionKind.Project) throw new Error(`Expected Project (${ReflectionKind.Project}), but received ${kindString} (${kind})`);
 
-      this.version = version;
+      this.version = version ?? null;
       this.classes = children.filter((child) => child.kind === ReflectionKind.Class).map((child) => ClassParser.generateFromTypeDoc(child, this));
       this.constants = children
         .filter((child) => child.kind === ReflectionKind.Variable)
@@ -309,6 +317,7 @@ export class ProjectParser {
       id: this.id,
       name: this.name,
       version: this.version,
+      readme: this.readme,
       classes: this.classes.map((parser) => parser.toJSON()),
       constants: this.constants.map((parser) => parser.toJSON()),
       enums: this.enums.map((parser) => parser.toJSON()),
@@ -321,6 +330,26 @@ export class ProjectParser {
 }
 
 export namespace ProjectParser {
+  export interface Options {
+    /**
+     * The data for this project.
+     * @since 3.0.0
+     */
+    data: JSON | JSONOutput.ProjectReflection;
+
+    /**
+     * The version of the project being parsed.
+     * @since 3.0.0
+     */
+    version?: string;
+
+    /**
+     * The readme content of this project.
+     * @since 3.0.0
+     */
+    readme?: string;
+  }
+
   export interface JSON {
     /**
      * The version of `typedoc-json-parser` that generated this JSON object.
@@ -349,6 +378,12 @@ export namespace ProjectParser {
      * @since 2.2.0
      */
     version: string | null;
+
+    /**
+     * The readme content of this project.
+     * @since 3.0.0
+     */
+    readme: string | null;
 
     /**
      * An array of class JSON compatible objects for this project in a JSON compatible format.

--- a/src/lib/structures/ProjectParser.ts
+++ b/src/lib/structures/ProjectParser.ts
@@ -95,13 +95,13 @@ export class ProjectParser {
 
     this.id = id;
     this.name = name;
-    this.readme = readme ?? null;
 
     if ('classes' in data) {
       const { typeDocJsonParserVersion, classes, constants, enums, functions, interfaces, namespaces, typeAliases } = data;
 
       this.typeDocJsonParserVersion = typeDocJsonParserVersion;
       this.version = version ?? data.version;
+      this.readme = readme ?? data.readme;
       this.classes = classes.map((json) => ClassParser.generateFromJSON(json, this));
       this.constants = constants.map((json) => ConstantParser.generateFromJSON(json, this));
       this.enums = enums.map((json) => EnumParser.generateFromJSON(json, this));
@@ -115,6 +115,7 @@ export class ProjectParser {
       if (kind !== ReflectionKind.Project) throw new Error(`Expected Project (${ReflectionKind.Project}), but received ${kindString} (${kind})`);
 
       this.version = version ?? null;
+      this.readme = readme ?? null;
       this.classes = children.filter((child) => child.kind === ReflectionKind.Class).map((child) => ClassParser.generateFromTypeDoc(child, this));
       this.constants = children
         .filter((child) => child.kind === ReflectionKind.Variable)


### PR DESCRIPTION
Resolves #37 

## Commit Body

```
BREAKING CHANGE: The constructor of `ProjectParser` now only accepts a single parameter of `ProjectParser.Options`
```