### PR TITLE
feat(class-parser): add `parent` getter

### DIFF
--- a/src/lib/structures/class-parser/ClassMethodParser.ts
+++ b/src/lib/structures/class-parser/ClassMethodParser.ts
@@ -11,6 +11,12 @@ import { ClassParser } from './ClassParser';
  */
 export class ClassMethodParser extends Parser {
   /**
+   * The id of the parent class parser.
+   * @since 4.0.0
+   */
+  public readonly parentId: number;
+
+  /**
    * The accessibility of this method.
    * @since 1.0.0
    */
@@ -37,12 +43,21 @@ export class ClassMethodParser extends Parser {
   public constructor(data: ClassMethodParser.Data, project: ProjectParser) {
     super(data, project);
 
-    const { accessibility, abstract, static: _static, signatures } = data;
+    const { parentId, accessibility, abstract, static: _static, signatures } = data;
 
+    this.parentId = parentId;
     this.accessibility = accessibility;
     this.abstract = abstract;
     this.static = _static;
     this.signatures = signatures;
+  }
+
+  /**
+   * The parent class parser.
+   * @since 4.0.0
+   */
+  public get parent(): ClassParser {
+    return this.project.find(this.parentId) as ClassParser;
   }
 
   /**
@@ -53,6 +68,7 @@ export class ClassMethodParser extends Parser {
   public toJSON(): ClassMethodParser.JSON {
     return {
       ...super.toJSON(),
+      parentId: this.parentId,
       accessibility: this.accessibility,
       abstract: this.abstract,
       static: this.static,
@@ -67,7 +83,7 @@ export class ClassMethodParser extends Parser {
    * @param project The project this parser belongs to.
    * @returns The generated parser.
    */
-  public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): ClassMethodParser {
+  public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, parentId: number, project: ProjectParser): ClassMethodParser {
     const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], flags, signatures = [] } = reflection;
 
     if (kind !== ReflectionKind.Method) throw new Error(`Expected Method (${ReflectionKind.Method}), but received ${kindString} (${kind})`);
@@ -78,6 +94,7 @@ export class ClassMethodParser extends Parser {
         name,
         comment: CommentParser.generateFromTypeDoc(comment, project),
         source: sources.length ? SourceParser.generateFromTypeDoc(sources[0], project) : null,
+        parentId,
         accessibility: flags.isPrivate
           ? ClassParser.Accessibility.Private
           : flags.isProtected
@@ -92,7 +109,7 @@ export class ClassMethodParser extends Parser {
   }
 
   public static generateFromJSON(json: ClassMethodParser.JSON, project: ProjectParser): ClassMethodParser {
-    const { id, name, comment, source, accessibility, abstract, static: _static, signatures } = json;
+    const { id, name, comment, source, parentId, accessibility, abstract, static: _static, signatures } = json;
 
     return new ClassMethodParser(
       {
@@ -100,6 +117,7 @@ export class ClassMethodParser extends Parser {
         name,
         comment: CommentParser.generateFromJSON(comment, project),
         source: source ? SourceParser.generateFromJSON(source, project) : null,
+        parentId,
         accessibility,
         abstract,
         static: _static,
@@ -112,6 +130,12 @@ export class ClassMethodParser extends Parser {
 
 export namespace ClassMethodParser {
   export interface Data extends Parser.Data {
+    /**
+     * The id of the parent class parser.
+     * @since 4.0.0
+     */
+    parentId: number;
+
     /**
      * The accessibility of this method.
      * @since 1.0.0
@@ -138,6 +162,12 @@ export namespace ClassMethodParser {
   }
 
   export interface JSON extends Parser.JSON {
+    /**
+     * The id of the parent class parser.
+     * @since 4.0.0
+     */
+    parentId: number;
+
     /**
      * The accessibility of this method.
      * @since 1.0.0

--- a/src/lib/structures/class-parser/ClassParser.ts
+++ b/src/lib/structures/class-parser/ClassParser.ts
@@ -116,11 +116,11 @@ export class ClassParser extends Parser {
 
     const properties = children
       .filter((child) => child.kind === ReflectionKind.Property || (child.kind === ReflectionKind.Accessor && child.getSignature))
-      .map((child) => ClassPropertyParser.generateFromTypeDoc(child, project));
+      .map((child) => ClassPropertyParser.generateFromTypeDoc(child, id, project));
 
     const methods = children
       .filter((child) => child.kind === ReflectionKind.Method)
-      .map((child) => ClassMethodParser.generateFromTypeDoc(child, project));
+      .map((child) => ClassMethodParser.generateFromTypeDoc(child, id, project));
 
     return new ClassParser(
       {
@@ -132,7 +132,7 @@ export class ClassParser extends Parser {
         abstract: Boolean(flags.isAbstract),
         extendsType: extendedTypes.length ? TypeParser.generateFromTypeDoc(extendedTypes[0]) : null,
         implementsType: implementedTypes.map((implementedType) => TypeParser.generateFromTypeDoc(implementedType)),
-        construct: ClassConstructorParser.generateFromTypeDoc(construct, project),
+        construct: ClassConstructorParser.generateFromTypeDoc(construct, id, project),
         properties,
         methods
       },

--- a/src/lib/structures/class-parser/ClassPropertyParser.ts
+++ b/src/lib/structures/class-parser/ClassPropertyParser.ts
@@ -12,6 +12,12 @@ import { ClassParser } from './ClassParser';
  */
 export class ClassPropertyParser extends Parser {
   /**
+   * The id of the parent class parser.
+   * @since 4.0.0
+   */
+  public readonly parentId: number;
+
+  /**
    * The accessibility of this property.
    * @since 1.0.0
    */
@@ -50,14 +56,23 @@ export class ClassPropertyParser extends Parser {
   public constructor(data: ClassPropertyParser.Data, project: ProjectParser) {
     super(data, project);
 
-    const { accessibility, abstract, static: _static, readonly, optional, type } = data;
+    const { parentId, accessibility, abstract, static: _static, readonly, optional, type } = data;
 
+    this.parentId = parentId;
     this.accessibility = accessibility;
     this.abstract = abstract;
     this.static = _static;
     this.readonly = readonly;
     this.optional = optional;
     this.type = type;
+  }
+
+  /**
+   * The parent class parser.
+   * @since 4.0.0
+   */
+  public get parent(): ClassParser {
+    return this.project.find(this.parentId) as ClassParser;
   }
 
   /**
@@ -68,6 +83,7 @@ export class ClassPropertyParser extends Parser {
   public toJSON(): ClassPropertyParser.JSON {
     return {
       ...super.toJSON(),
+      parentId: this.parentId,
       accessibility: this.accessibility,
       abstract: this.abstract,
       static: this.static,
@@ -84,7 +100,7 @@ export class ClassPropertyParser extends Parser {
    * @param project The project this parser belongs to.
    * @returns The generated parser.
    */
-  public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): ClassPropertyParser {
+  public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, parentId: number, project: ProjectParser): ClassPropertyParser {
     const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], type, flags, getSignature } = reflection;
 
     if (kind !== ReflectionKind.Property && kind !== ReflectionKind.Accessor) {
@@ -104,6 +120,7 @@ export class ClassPropertyParser extends Parser {
           name,
           comment: CommentParser.generateFromTypeDoc(comment, project),
           source: sources.length ? SourceParser.generateFromTypeDoc(sources[0], project) : null,
+          parentId,
           accessibility: flags.isPrivate
             ? ClassParser.Accessibility.Private
             : flags.isProtected
@@ -125,6 +142,7 @@ export class ClassPropertyParser extends Parser {
         name,
         comment: CommentParser.generateFromTypeDoc(comment, project),
         source: sources.length ? SourceParser.generateFromTypeDoc(sources[0], project) : null,
+        parentId,
         accessibility: flags.isPrivate
           ? ClassParser.Accessibility.Private
           : flags.isProtected
@@ -141,7 +159,7 @@ export class ClassPropertyParser extends Parser {
   }
 
   public static generateFromJSON(json: ClassPropertyParser.JSON, project: ProjectParser): ClassPropertyParser {
-    const { id, name, comment, source, accessibility, abstract, static: _static, readonly, optional, type } = json;
+    const { id, name, comment, source, parentId, accessibility, abstract, static: _static, readonly, optional, type } = json;
 
     return new ClassPropertyParser(
       {
@@ -149,6 +167,7 @@ export class ClassPropertyParser extends Parser {
         name,
         comment: CommentParser.generateFromJSON(comment, project),
         source: source ? SourceParser.generateFromJSON(source, project) : null,
+        parentId,
         accessibility,
         abstract,
         static: _static,
@@ -163,6 +182,12 @@ export class ClassPropertyParser extends Parser {
 
 export namespace ClassPropertyParser {
   export interface Data extends Parser.Data {
+    /**
+     * The id of the parent class parser.
+     * @since 4.0.0
+     */
+    parentId: number;
+
     /**
      * The accessibility of this property.
      * @since 1.0.0
@@ -201,6 +226,12 @@ export namespace ClassPropertyParser {
   }
 
   export interface JSON extends Parser.JSON {
+    /**
+     * The id of the parent class parser.
+     * @since 4.0.0
+     */
+    parentId: number;
+
     /**
      * The accessibility of this property.
      * @since 1.0.0


### PR DESCRIPTION
## Commit Body

```
BREAKING CHANGE: `ClassConstructorParser.generateFromTypeDoc()` now takes 3 parameters instead of 2.
BREAKING CHANGE: `ClassMethodParser.generateFromTypeDoc()` now takes 3 parameters instead of 2.
BREAKING CHANGE: `ClassPropertyParser.generateFromTypeDoc()` now takes 3 parameters instead of 2.
```