### PR TITLE
feat(enum-parser): add `parent` getter

### DIFF
--- a/src/lib/structures/enum-parser/EnumParser.ts
+++ b/src/lib/structures/enum-parser/EnumParser.ts
@@ -58,7 +58,7 @@ export class EnumParser extends Parser {
 
     const properties = children
       .filter((child) => child.kind === ReflectionKind.EnumMember)
-      .map((child) => EnumPropertyParser.generateFromTypeDoc(child, project));
+      .map((child) => EnumPropertyParser.generateFromTypeDoc(child, id, project));
 
     return new EnumParser(
       {


### PR DESCRIPTION
## Commit Body

```
BREAKING CHANGE: `EnumPropertyParser.generateFromTypeDoc()` now takes 3 parameters instead of 2.
```