### PR TITLE
feat(interface-parser): add `parent` getter

### DIFF
--- a/src/lib/structures/interface-parser/InterfaceMethodParser.ts
+++ b/src/lib/structures/interface-parser/InterfaceMethodParser.ts
@@ -3,12 +3,19 @@ import { ReflectionKind } from '../../types';
 import { CommentParser, SignatureParser, SourceParser } from '../misc';
 import { Parser } from '../Parser';
 import type { ProjectParser } from '../ProjectParser';
+import type { InterfaceParser } from './InterfaceParser';
 
 /**
  * Parses data from an interface method reflection.
  * @since 3.1.0
  */
 export class InterfaceMethodParser extends Parser {
+  /**
+   * The id of the parent interface parser.
+   * @since 4.0.0
+   */
+  public readonly parentId: number;
+
   /**
    * The signature parsers of this method.
    * @since 3.1.0
@@ -18,9 +25,18 @@ export class InterfaceMethodParser extends Parser {
   public constructor(data: InterfaceMethodParser.Data, project: ProjectParser) {
     super(data, project);
 
-    const { signatures } = data;
+    const { parentId, signatures } = data;
 
+    this.parentId = parentId;
     this.signatures = signatures;
+  }
+
+  /**
+   * The parent interface parser.
+   * @since 4.0.0
+   */
+  public get parent(): InterfaceParser {
+    return this.project.find(this.parentId) as InterfaceParser;
   }
 
   /**
@@ -31,18 +47,19 @@ export class InterfaceMethodParser extends Parser {
   public toJSON(): InterfaceMethodParser.JSON {
     return {
       ...super.toJSON(),
+      parentId: this.parentId,
       signatures: this.signatures.map((signature) => signature.toJSON())
     };
   }
 
   /**
    * Generates a new {@link InterfaceMethodParser} instance from the given data.
-   * @since 1.0.0
+   * @since 3.1.0
    * @param reflection The reflection to generate the parser from.
    * @param project The project this parser belongs to.
    * @returns The generated parser.
    */
-  public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): InterfaceMethodParser {
+  public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, parentId: number, project: ProjectParser): InterfaceMethodParser {
     const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], signatures = [] } = reflection;
 
     if (kind !== ReflectionKind.Method) throw new Error(`Expected Method (${ReflectionKind.Method}), but received ${kindString} (${kind})`);
@@ -53,6 +70,7 @@ export class InterfaceMethodParser extends Parser {
         name,
         comment: CommentParser.generateFromTypeDoc(comment, project),
         source: sources.length ? SourceParser.generateFromTypeDoc(sources[0], project) : null,
+        parentId,
         signatures: signatures.map((signature) => SignatureParser.generateFromTypeDoc(signature, project))
       },
       project
@@ -60,7 +78,7 @@ export class InterfaceMethodParser extends Parser {
   }
 
   public static generateFromJSON(json: InterfaceMethodParser.JSON, project: ProjectParser): InterfaceMethodParser {
-    const { id, name, comment, source, signatures } = json;
+    const { id, name, comment, source, parentId, signatures } = json;
 
     return new InterfaceMethodParser(
       {
@@ -68,6 +86,7 @@ export class InterfaceMethodParser extends Parser {
         name,
         comment: CommentParser.generateFromJSON(comment, project),
         source: source ? SourceParser.generateFromJSON(source, project) : null,
+        parentId,
         signatures: signatures.map((signature) => SignatureParser.generateFromJSON(signature, project))
       },
       project
@@ -78,6 +97,12 @@ export class InterfaceMethodParser extends Parser {
 export namespace InterfaceMethodParser {
   export interface Data extends Parser.Data {
     /**
+     * The id of the parent interface parser.
+     * @since 4.0.0
+     */
+    parentId: number;
+
+    /**
      * The signature parsers of this method.
      * @since 3.1.0
      */
@@ -85,6 +110,12 @@ export namespace InterfaceMethodParser {
   }
 
   export interface JSON extends Parser.JSON {
+    /**
+     * The id of the parent interface parser.
+     * @since 4.0.0
+     */
+    parentId: number;
+
     /**
      * The signature parsers of this method in a JSON compatible format.
      * @since 3.1.0

--- a/src/lib/structures/interface-parser/InterfaceParser.ts
+++ b/src/lib/structures/interface-parser/InterfaceParser.ts
@@ -67,11 +67,11 @@ export class InterfaceParser extends Parser {
 
     const properties = children
       .filter((child) => child.kind === ReflectionKind.Property)
-      .map((child) => InterfacePropertyParser.generateFromTypeDoc(child, project));
+      .map((child) => InterfacePropertyParser.generateFromTypeDoc(child, id, project));
 
     const methods = children
       .filter((child) => child.kind === ReflectionKind.Method)
-      .map((child) => InterfaceMethodParser.generateFromTypeDoc(child, project));
+      .map((child) => InterfaceMethodParser.generateFromTypeDoc(child, id, project));
 
     return new InterfaceParser(
       {

--- a/src/lib/structures/interface-parser/InterfacePropertyParser.ts
+++ b/src/lib/structures/interface-parser/InterfacePropertyParser.ts
@@ -4,12 +4,19 @@ import { CommentParser, SourceParser } from '../misc';
 import { Parser } from '../Parser';
 import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from '../type-parsers';
+import type { InterfaceParser } from './InterfaceParser';
 
 /**
  * Parses data from an interface property reflection.
  * @since 1.0.0
  */
 export class InterfacePropertyParser extends Parser {
+  /**
+   * The id of the parent interface parser.
+   * @since 4.0.0
+   */
+  public readonly parentId: number;
+
   /**
    * Whether this interface property is readonly.
    * @since 1.0.0
@@ -25,10 +32,19 @@ export class InterfacePropertyParser extends Parser {
   public constructor(data: InterfacePropertyParser.Data, project: ProjectParser) {
     super(data, project);
 
-    const { readonly, type } = data;
+    const { parentId, readonly, type } = data;
 
+    this.parentId = parentId;
     this.readonly = readonly;
     this.type = type;
+  }
+
+  /**
+   * The parent interface parser.
+   * @since 4.0.0
+   */
+  public get parent(): InterfaceParser {
+    return this.project.find(this.parentId) as InterfaceParser;
   }
 
   /**
@@ -39,6 +55,7 @@ export class InterfacePropertyParser extends Parser {
   public toJSON(): InterfacePropertyParser.JSON {
     return {
       ...super.toJSON(),
+      parentId: this.parentId,
       readonly: this.readonly,
       type: this.type.toJSON()
     };
@@ -51,7 +68,7 @@ export class InterfacePropertyParser extends Parser {
    * @param project The project this parser belongs to.
    * @returns The generated parser.
    */
-  public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, project: ProjectParser): InterfacePropertyParser {
+  public static generateFromTypeDoc(reflection: JSONOutput.DeclarationReflection, parentId: number, project: ProjectParser): InterfacePropertyParser {
     const { kind, kindString = 'Unknown', id, name, comment = { summary: [] }, sources = [], type, flags } = reflection;
 
     if (kind !== ReflectionKind.Property) throw new Error(`Expected Property (${ReflectionKind.Property}), but received ${kindString} (${kind})`);
@@ -62,6 +79,7 @@ export class InterfacePropertyParser extends Parser {
         name,
         comment: CommentParser.generateFromTypeDoc(comment, project),
         source: sources.length ? SourceParser.generateFromTypeDoc(sources[0], project) : null,
+        parentId,
         readonly: Boolean(flags.isReadonly),
         type: TypeParser.generateFromTypeDoc(type!)
       },
@@ -70,7 +88,7 @@ export class InterfacePropertyParser extends Parser {
   }
 
   public static generateFromJSON(json: InterfacePropertyParser.JSON, project: ProjectParser): InterfacePropertyParser {
-    const { id, name, comment, source, readonly, type } = json;
+    const { id, name, comment, source, parentId, readonly, type } = json;
 
     return new InterfacePropertyParser(
       {
@@ -78,6 +96,7 @@ export class InterfacePropertyParser extends Parser {
         name,
         comment: CommentParser.generateFromJSON(comment, project),
         source: source ? SourceParser.generateFromJSON(source, project) : null,
+        parentId,
         readonly,
         type: TypeParser.generateFromJSON(type)
       },
@@ -88,6 +107,12 @@ export class InterfacePropertyParser extends Parser {
 
 export namespace InterfacePropertyParser {
   export interface Data extends Parser.Data {
+    /**
+     * The id of the parent interface parser.
+     * @since 4.0.0
+     */
+    parentId: number;
+
     /**
      * Whether this interface property is readonly.
      * @since 1.0.0
@@ -102,6 +127,12 @@ export namespace InterfacePropertyParser {
   }
 
   export interface JSON extends Parser.JSON {
+    /**
+     * The id of the parent interface parser.
+     * @since 4.0.0
+     */
+    parentId: number;
+
     /**
      * Whether this interface property is readonly.
      * @since 1.0.0


### PR DESCRIPTION
## Commit Body

```
BREAKING CHANGE: `InterfaceMethodParser.generateFromTypeDoc()` now takes 3 parameters instead of 2.
BREAKING CHANGE: `InterfacePropertyParser.generateFromTypeDoc()` now takes 3 parameters instead of 2.
```