### PR TITLE
feat(TypeParser): add `project` property

### DIFF
--- a/src/lib/structures/ConstantParser.ts
+++ b/src/lib/structures/ConstantParser.ts
@@ -71,7 +71,7 @@ export class ConstantParser extends Parser {
         comment: CommentParser.generateFromTypeDoc(comment, project),
         source: sources.length ? SourceParser.generateFromTypeDoc(sources[0], project) : null,
         external: Boolean(flags.isExternal),
-        type: TypeParser.generateFromTypeDoc(type!),
+        type: TypeParser.generateFromTypeDoc(type!, project),
         value: defaultValue!
       },
       project
@@ -88,7 +88,7 @@ export class ConstantParser extends Parser {
         comment: CommentParser.generateFromJSON(comment, project),
         source: source ? SourceParser.generateFromJSON(source, project) : null,
         external,
-        type: TypeParser.generateFromJSON(type),
+        type: TypeParser.generateFromJSON(type, project),
         value
       },
       project

--- a/src/lib/structures/TypeAliasParser.ts
+++ b/src/lib/structures/TypeAliasParser.ts
@@ -72,7 +72,7 @@ export class TypeAliasParser extends Parser {
         source: sources.length ? SourceParser.generateFromTypeDoc(sources[0], project) : null,
         external: Boolean(flags.isExternal),
         typeParameters: typeParameters.map((typeParameter) => TypeParameterParser.generateFromTypeDoc(typeParameter, project)),
-        type: TypeParser.generateFromTypeDoc(type!)
+        type: TypeParser.generateFromTypeDoc(type!, project)
       },
       project
     );
@@ -89,7 +89,7 @@ export class TypeAliasParser extends Parser {
         source: source ? SourceParser.generateFromJSON(source, project) : null,
         external,
         typeParameters: typeParameters.map((typeParameter) => TypeParameterParser.generateFromJSON(typeParameter, project)),
-        type: TypeParser.generateFromJSON(type)
+        type: TypeParser.generateFromJSON(type, project)
       },
       project
     );

--- a/src/lib/structures/class-parser/ClassParser.ts
+++ b/src/lib/structures/class-parser/ClassParser.ts
@@ -130,8 +130,8 @@ export class ClassParser extends Parser {
         source: sources.length ? SourceParser.generateFromTypeDoc(sources[0], project) : null,
         external: Boolean(flags.isExternal),
         abstract: Boolean(flags.isAbstract),
-        extendsType: extendedTypes.length ? TypeParser.generateFromTypeDoc(extendedTypes[0]) : null,
-        implementsType: implementedTypes.map((implementedType) => TypeParser.generateFromTypeDoc(implementedType)),
+        extendsType: extendedTypes.length ? TypeParser.generateFromTypeDoc(extendedTypes[0], project) : null,
+        implementsType: implementedTypes.map((implementedType) => TypeParser.generateFromTypeDoc(implementedType, project)),
         construct: ClassConstructorParser.generateFromTypeDoc(construct, id, project),
         properties,
         methods
@@ -151,8 +151,8 @@ export class ClassParser extends Parser {
         source: source ? SourceParser.generateFromJSON(source, project) : null,
         external,
         abstract,
-        extendsType: extendsType ? TypeParser.generateFromJSON(extendsType) : null,
-        implementsType: implementsType.map((implementedType) => TypeParser.generateFromJSON(implementedType)),
+        extendsType: extendsType ? TypeParser.generateFromJSON(extendsType, project) : null,
+        implementsType: implementsType.map((implementedType) => TypeParser.generateFromJSON(implementedType, project)),
         construct: ClassConstructorParser.generateFromJSON(construct, project),
         properties: properties.map((property) => ClassPropertyParser.generateFromJSON(property, project)),
         methods: methods.map((method) => ClassMethodParser.generateFromJSON(method, project))

--- a/src/lib/structures/class-parser/ClassPropertyParser.ts
+++ b/src/lib/structures/class-parser/ClassPropertyParser.ts
@@ -130,7 +130,7 @@ export class ClassPropertyParser extends Parser {
           static: Boolean(flags.isStatic),
           readonly: Boolean(flags.isReadonly),
           optional: Boolean(flags.isOptional),
-          type: type ? TypeParser.generateFromTypeDoc(type) : null
+          type: type ? TypeParser.generateFromTypeDoc(type, project) : null
         },
         project
       );
@@ -152,7 +152,7 @@ export class ClassPropertyParser extends Parser {
         static: Boolean(flags.isStatic),
         readonly: Boolean(flags.isReadonly),
         optional: Boolean(flags.isOptional),
-        type: type ? TypeParser.generateFromTypeDoc(type) : null
+        type: type ? TypeParser.generateFromTypeDoc(type, project) : null
       },
       project
     );
@@ -173,7 +173,7 @@ export class ClassPropertyParser extends Parser {
         static: _static,
         readonly,
         optional,
-        type: type ? TypeParser.generateFromJSON(type) : null
+        type: type ? TypeParser.generateFromJSON(type, project) : null
       },
       project
     );

--- a/src/lib/structures/enum-parser/EnumPropertyParser.ts
+++ b/src/lib/structures/enum-parser/EnumPropertyParser.ts
@@ -89,7 +89,7 @@ export class EnumPropertyParser extends Parser {
         comment: CommentParser.generateFromTypeDoc(comment, project),
         source: sources.length ? SourceParser.generateFromTypeDoc(sources[0], project) : null,
         parentId,
-        value: TypeParser.generateFromTypeDoc(type!).toString()
+        value: TypeParser.generateFromTypeDoc(type!, project).toString()
       },
       project
     );

--- a/src/lib/structures/interface-parser/InterfacePropertyParser.ts
+++ b/src/lib/structures/interface-parser/InterfacePropertyParser.ts
@@ -81,7 +81,7 @@ export class InterfacePropertyParser extends Parser {
         source: sources.length ? SourceParser.generateFromTypeDoc(sources[0], project) : null,
         parentId,
         readonly: Boolean(flags.isReadonly),
-        type: TypeParser.generateFromTypeDoc(type!)
+        type: TypeParser.generateFromTypeDoc(type!, project)
       },
       project
     );
@@ -98,7 +98,7 @@ export class InterfacePropertyParser extends Parser {
         source: source ? SourceParser.generateFromJSON(source, project) : null,
         parentId,
         readonly,
-        type: TypeParser.generateFromJSON(type)
+        type: TypeParser.generateFromJSON(type, project)
       },
       project
     );

--- a/src/lib/structures/misc/ParameterParser.ts
+++ b/src/lib/structures/misc/ParameterParser.ts
@@ -73,7 +73,7 @@ export class ParameterParser {
       {
         id,
         name,
-        type: TypeParser.generateFromTypeDoc(type!)
+        type: TypeParser.generateFromTypeDoc(type!, project)
       },
       project
     );
@@ -86,7 +86,7 @@ export class ParameterParser {
       {
         id,
         name,
-        type: TypeParser.generateFromJSON(type)
+        type: TypeParser.generateFromJSON(type, project)
       },
       project
     );

--- a/src/lib/structures/misc/SignatureParser.ts
+++ b/src/lib/structures/misc/SignatureParser.ts
@@ -112,7 +112,7 @@ export class SignatureParser {
         comment: CommentParser.generateFromTypeDoc(comment, project),
         typeParameters: typeParameters.map((typeParameter) => TypeParameterParser.generateFromTypeDoc(typeParameter, project)),
         parameters: parameters.map((parameter) => ParameterParser.generateFromTypeDoc(parameter, project)),
-        returnType: TypeParser.generateFromTypeDoc(type!)
+        returnType: TypeParser.generateFromTypeDoc(type!, project)
       },
       project
     );
@@ -128,7 +128,7 @@ export class SignatureParser {
         comment: CommentParser.generateFromJSON(comment, project),
         typeParameters: typeParameters.map((typeParameter) => TypeParameterParser.generateFromJSON(typeParameter, project)),
         parameters: parameters.map((parameter) => ParameterParser.generateFromJSON(parameter, project)),
-        returnType: TypeParser.generateFromJSON(returnType)
+        returnType: TypeParser.generateFromJSON(returnType, project)
       },
       project
     );

--- a/src/lib/structures/misc/TypeParameterParser.ts
+++ b/src/lib/structures/misc/TypeParameterParser.ts
@@ -81,8 +81,8 @@ export class TypeParameterParser {
       {
         id,
         name,
-        type: type ? TypeParser.generateFromTypeDoc(type) : null,
-        default: _default ? TypeParser.generateFromTypeDoc(_default) : null
+        type: type ? TypeParser.generateFromTypeDoc(type, project) : null,
+        default: _default ? TypeParser.generateFromTypeDoc(_default, project) : null
       },
       project
     );
@@ -95,8 +95,8 @@ export class TypeParameterParser {
       {
         id,
         name,
-        type: type ? TypeParser.generateFromJSON(type) : null,
-        default: _default ? TypeParser.generateFromJSON(_default) : null
+        type: type ? TypeParser.generateFromJSON(type, project) : null,
+        default: _default ? TypeParser.generateFromJSON(_default, project) : null
       },
       project
     );

--- a/src/lib/structures/type-parsers/ArrayTypeParser.ts
+++ b/src/lib/structures/type-parsers/ArrayTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class ArrayTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -17,8 +24,12 @@ export class ArrayTypeParser implements TypeParser {
    */
   public readonly type: TypeParser;
 
-  public constructor(type: TypeParser) {
+  public constructor(data: ArrayTypeParser.Data, project: ProjectParser) {
+    const { type } = data;
+
     this.type = type;
+
+    this.project = project;
   }
 
   /**
@@ -54,6 +65,14 @@ export class ArrayTypeParser implements TypeParser {
 }
 
 export namespace ArrayTypeParser {
+  export interface Data {
+    /**
+     * The type of this array type.
+     * @since 5.0.0
+     */
+    type: TypeParser;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Array;
 

--- a/src/lib/structures/type-parsers/ConditionalTypeParser.ts
+++ b/src/lib/structures/type-parsers/ConditionalTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,11 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class ConditionalTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -35,11 +41,15 @@ export class ConditionalTypeParser implements TypeParser {
    */
   public readonly falseType: TypeParser;
 
-  public constructor(checkType: TypeParser, extendsType: TypeParser, trueType: TypeParser, falseType: TypeParser) {
+  public constructor(data: ConditionalTypeParser.Data, project: ProjectParser) {
+    const { checkType, extendsType, trueType, falseType } = data;
+
     this.checkType = checkType;
     this.extendsType = extendsType;
     this.trueType = trueType;
     this.falseType = falseType;
+
+    this.project = project;
   }
 
   /**
@@ -81,6 +91,32 @@ export class ConditionalTypeParser implements TypeParser {
 }
 
 export namespace ConditionalTypeParser {
+  export interface Data {
+    /**
+     * The check type of this conditional type.
+     * @since 5.0.0
+     */
+    checkType: TypeParser;
+
+    /**
+     * The extends type of this conditional type.
+     * @since 5.0.0
+     */
+    extendsType: TypeParser;
+
+    /**
+     * The type of this conditional type when the check type is true.
+     * @since 5.0.0
+     */
+    trueType: TypeParser;
+
+    /**
+     * The type of this conditional type when the check type is false.
+     * @since 5.0.0
+     */
+    falseType: TypeParser;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Conditional;
 
@@ -104,6 +140,7 @@ export namespace ConditionalTypeParser {
 
     /**
      * The type of this conditional type when the check type is false in a JSON compatible format.
+     * @since 1.0.0
      */
     falseType: TypeParser.JSON;
   }

--- a/src/lib/structures/type-parsers/IndexedAccessType.ts
+++ b/src/lib/structures/type-parsers/IndexedAccessType.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class IndexedAccessTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -23,9 +30,13 @@ export class IndexedAccessTypeParser implements TypeParser {
    */
   public readonly indexType: TypeParser;
 
-  public constructor(objectType: TypeParser, indexType: TypeParser) {
+  public constructor(data: IndexedAccessTypeParser.Data, project: ProjectParser) {
+    const { objectType, indexType } = data;
+
     this.objectType = objectType;
     this.indexType = indexType;
+
+    this.project = project;
   }
 
   /**
@@ -62,6 +73,20 @@ export class IndexedAccessTypeParser implements TypeParser {
 }
 
 export namespace IndexedAccessTypeParser {
+  export interface Data {
+    /**
+     * The object type of this indexed access type.
+     * @since 5.0.0
+     */
+    objectType: TypeParser;
+
+    /**
+     * The index type of this indexed access type.
+     * @since 5.0.0
+     */
+    indexType: TypeParser;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.IndexedAccess;
 

--- a/src/lib/structures/type-parsers/InferredTypeParser.ts
+++ b/src/lib/structures/type-parsers/InferredTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class InferredTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -17,8 +24,12 @@ export class InferredTypeParser implements TypeParser {
    */
   public readonly type: string;
 
-  public constructor(type: string) {
+  public constructor(data: InferredTypeParser.Data, project: ProjectParser) {
+    const { type } = data;
+
     this.type = type;
+
+    this.project = project;
   }
 
   /**
@@ -54,6 +65,14 @@ export class InferredTypeParser implements TypeParser {
 }
 
 export namespace InferredTypeParser {
+  export interface Data {
+    /**
+     * The type of this inferred type.
+     * @since 5.0.0
+     */
+    type: string;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Inferred;
 

--- a/src/lib/structures/type-parsers/IntersectionTypeParser.ts
+++ b/src/lib/structures/type-parsers/IntersectionTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class IntersectionTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -17,8 +24,12 @@ export class IntersectionTypeParser implements TypeParser {
    */
   public readonly types: TypeParser[];
 
-  public constructor(types: TypeParser[]) {
+  public constructor(data: IntersectionTypeParser.Data, project: ProjectParser) {
+    const { types } = data;
+
     this.types = types;
+
+    this.project = project;
   }
 
   /**
@@ -54,6 +65,14 @@ export class IntersectionTypeParser implements TypeParser {
 }
 
 export namespace IntersectionTypeParser {
+  export interface Data {
+    /**
+     * The types of this intersection type.
+     * @since 5.0.0
+     */
+    types: TypeParser[];
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Intersection;
 

--- a/src/lib/structures/type-parsers/IntrinsicTypeParser.ts
+++ b/src/lib/structures/type-parsers/IntrinsicTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class IntrinsicTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -17,8 +24,12 @@ export class IntrinsicTypeParser implements TypeParser {
    */
   public readonly type: string;
 
-  public constructor(type: string) {
+  public constructor(data: IntrinsicTypeParser.Data, project: ProjectParser) {
+    const { type } = data;
+
     this.type = type;
+
+    this.project = project;
   }
 
   /**
@@ -54,6 +65,14 @@ export class IntrinsicTypeParser implements TypeParser {
 }
 
 export namespace IntrinsicTypeParser {
+  export interface Data {
+    /**
+     * The type of this intrinsic type.
+     * @since 5.0.0
+     */
+    type: string;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Intrinsic;
 

--- a/src/lib/structures/type-parsers/LiteralTypeParser.ts
+++ b/src/lib/structures/type-parsers/LiteralTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class LiteralTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -17,8 +24,12 @@ export class LiteralTypeParser implements TypeParser {
    */
   public readonly value: string;
 
-  public constructor(value: string) {
+  public constructor(data: LiteralTypeParser.Data, project: ProjectParser) {
+    const { value } = data;
+
     this.value = value;
+
+    this.project = project;
   }
 
   /**
@@ -54,6 +65,14 @@ export class LiteralTypeParser implements TypeParser {
 }
 
 export namespace LiteralTypeParser {
+  export interface Data {
+    /**
+     * The value of this literal type.
+     * @since 5.0.0
+     */
+    value: string;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Literal;
 

--- a/src/lib/structures/type-parsers/MappedTypeParser.ts
+++ b/src/lib/structures/type-parsers/MappedTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class MappedTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -47,20 +54,17 @@ export class MappedTypeParser implements TypeParser {
    */
   public readonly optional: MappedTypeParser.Modifier | null;
 
-  public constructor(
-    parameter: string,
-    parameterType: TypeParser,
-    nameType: TypeParser | null,
-    templateType: TypeParser,
-    readonly: MappedTypeParser.Modifier | null,
-    optional: MappedTypeParser.Modifier | null
-  ) {
+  public constructor(data: MappedTypeParser.Data, project: ProjectParser) {
+    const { parameter, parameterType, nameType, templateType, readonly, optional } = data;
+
     this.parameter = parameter;
     this.parameterType = parameterType;
     this.nameType = nameType;
     this.templateType = templateType;
     this.readonly = readonly;
     this.optional = optional;
+
+    this.project = project;
   }
 
   /**
@@ -106,6 +110,44 @@ export class MappedTypeParser implements TypeParser {
 }
 
 export namespace MappedTypeParser {
+  export interface Data {
+    /**
+     * The parameter name of this mapped type.
+     * @since 5.0.0
+     */
+    parameter: string;
+
+    /**
+     * The parameter type of this mapped type.
+     * @since 5.0.0
+     */
+    parameterType: TypeParser;
+
+    /**
+     * The name type of this mapped type.
+     * @since 5.0.0
+     */
+    nameType: TypeParser | null;
+
+    /**
+     * The template type of this mapped type.
+     * @since 5.0.0
+     */
+    templateType: TypeParser;
+
+    /**
+     * The readonly modifier of this mapped type.
+     * @since 5.0.0
+     */
+    readonly: Modifier | null;
+
+    /**
+     * The optional modifier of this mapped type.
+     * @since 5.0.0
+     */
+    optional: Modifier | null;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Mapped;
 

--- a/src/lib/structures/type-parsers/NamedTupleMemberTypeParser.ts
+++ b/src/lib/structures/type-parsers/NamedTupleMemberTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class NamedTupleMemberTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The name of this named tuple member.
    * @since 1.0.0
@@ -29,10 +36,14 @@ export class NamedTupleMemberTypeParser implements TypeParser {
    */
   public readonly optional: boolean;
 
-  public constructor(name: string, type: TypeParser, optional: boolean) {
+  public constructor(data: NamedTupleMemberTypeParser.Data, project: ProjectParser) {
+    const { name, type, optional } = data;
+
     this.name = name;
     this.type = type;
     this.optional = optional;
+
+    this.project = project;
   }
 
   /**
@@ -70,6 +81,26 @@ export class NamedTupleMemberTypeParser implements TypeParser {
 }
 
 export namespace NamedTupleMemberTypeParser {
+  export interface Data {
+    /**
+     * The name of this named tuple member.
+     * @since 5.0.0
+     */
+    name: string;
+
+    /**
+     * The type of this named tuple member.
+     * @since 5.0.0
+     */
+    type: TypeParser;
+
+    /**
+     * Whether this named tuple member is optional.
+     * @since 5.0.0
+     */
+    optional: boolean;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.NamedTupleMember;
 

--- a/src/lib/structures/type-parsers/OptionalTypeParser.ts
+++ b/src/lib/structures/type-parsers/OptionalTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class OptionalTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -17,8 +24,12 @@ export class OptionalTypeParser implements TypeParser {
    */
   public readonly type: TypeParser;
 
-  public constructor(type: TypeParser) {
+  public constructor(data: OptionalTypeParser.Data, project: ProjectParser) {
+    const { type } = data;
+
     this.type = type;
+
+    this.project = project;
   }
 
   /**
@@ -54,6 +65,14 @@ export class OptionalTypeParser implements TypeParser {
 }
 
 export namespace OptionalTypeParser {
+  export interface Data {
+    /**
+     * The type of this optional type.
+     * @since 5.0.0
+     */
+    type: TypeParser;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Optional;
 

--- a/src/lib/structures/type-parsers/PredicateTypeParser.ts
+++ b/src/lib/structures/type-parsers/PredicateTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class PredicateTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -30,10 +37,14 @@ export class PredicateTypeParser implements TypeParser {
    */
   public readonly type: TypeParser | null;
 
-  public constructor(asserts: boolean, name: string, type: TypeParser | null) {
+  public constructor(data: PredicateTypeParser.Data, project: ProjectParser) {
+    const { asserts, name, type } = data;
+
     this.asserts = asserts;
     this.name = name;
     this.type = type;
+
+    this.project = project;
   }
 
   /**
@@ -71,6 +82,28 @@ export class PredicateTypeParser implements TypeParser {
 }
 
 export namespace PredicateTypeParser {
+  export interface Data {
+    /**
+     * Whether this predicate type asserts a value.
+     * @since 5.0.0
+     */
+    asserts: boolean;
+
+    /**
+     * The name of this predicate type.
+     * @since 5.0.0
+     */
+    name: string;
+
+    /**
+     * The type of this predicate type.
+     *
+     * If this {@link PredicateTypeParser.asserts} is `false` this will not be `null`
+     * @since 5.0.0
+     */
+    type: TypeParser | null;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Predicate;
 
@@ -90,6 +123,7 @@ export namespace PredicateTypeParser {
      * The type of this predicate type in a JSON compatible format.
      *
      * If this {@link PredicateTypeParser.asserts} is `false` this will not be `null`
+     * @since 1.0.0
      */
     type: TypeParser.JSON | null;
   }

--- a/src/lib/structures/type-parsers/QueryTypeParser.ts
+++ b/src/lib/structures/type-parsers/QueryTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import type { ReferenceTypeParser } from './ReferenceTypeParser';
 import { TypeParser } from './TypeParser';
 
@@ -6,6 +7,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class QueryTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -18,8 +25,12 @@ export class QueryTypeParser implements TypeParser {
    */
   public readonly query: ReferenceTypeParser;
 
-  public constructor(query: ReferenceTypeParser) {
+  public constructor(data: QueryTypeParser.Data, project: ProjectParser) {
+    const { query } = data;
+
     this.query = query;
+
+    this.project = project;
   }
 
   /**
@@ -55,11 +66,19 @@ export class QueryTypeParser implements TypeParser {
 }
 
 export namespace QueryTypeParser {
+  export interface Data {
+    /**
+     * The query of this query type.
+     * @since 5.0.0
+     */
+    query: ReferenceTypeParser;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Query;
 
     /**
-     * The query of this query type.
+     * The query of this query type in a JSON compatible format.
      * @since 1.0.0
      */
     query: ReferenceTypeParser.JSON;

--- a/src/lib/structures/type-parsers/ReferenceTypeParser.ts
+++ b/src/lib/structures/type-parsers/ReferenceTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class ReferenceTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -35,11 +42,15 @@ export class ReferenceTypeParser implements TypeParser {
    */
   public readonly typeArguments: TypeParser[];
 
-  public constructor(id: number | null, name: string, packageName: string | null, typeArguments: TypeParser[]) {
+  public constructor(data: ReferenceTypeParser.Data, project: ProjectParser) {
+    const { id, name, packageName, typeArguments } = data;
+
     this.id = id;
     this.name = name;
     this.packageName = packageName;
     this.typeArguments = typeArguments;
+
+    this.project = project;
   }
 
   /**
@@ -89,6 +100,32 @@ export class ReferenceTypeParser implements TypeParser {
 }
 
 export namespace ReferenceTypeParser {
+  export interface Data {
+    /**
+     * The id of this reference type.
+     * @since 5.0.0
+     */
+    id: number | null;
+
+    /**
+     * The name of this reference type.
+     * @since 5.0.0
+     */
+    name: string;
+
+    /**
+     * The package name of this reference type.
+     * @since 5.0.0
+     */
+    packageName: string | null;
+
+    /**
+     * The type arguments of this reference type.
+     * @since 5.0.0
+     */
+    typeArguments: TypeParser[];
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Reference;
 
@@ -112,6 +149,7 @@ export namespace ReferenceTypeParser {
 
     /**
      * The type arguments of this reference type in a JSON compatible format.
+     * @since 1.0.0
      */
     typeArguments: TypeParser.JSON[];
   }

--- a/src/lib/structures/type-parsers/ReflectionTypeParser.ts
+++ b/src/lib/structures/type-parsers/ReflectionTypeParser.ts
@@ -1,4 +1,5 @@
 import type { JSONOutput } from 'typedoc';
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -6,6 +7,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class ReflectionTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -18,8 +25,12 @@ export class ReflectionTypeParser implements TypeParser {
    */
   public reflection: JSONOutput.DeclarationReflection | null;
 
-  public constructor(reflection: JSONOutput.DeclarationReflection | null) {
+  public constructor(data: ReflectionTypeParser.Data, project: ProjectParser) {
+    const { reflection } = data;
+
     this.reflection = reflection;
+
+    this.project = project;
   }
 
   /**
@@ -55,6 +66,14 @@ export class ReflectionTypeParser implements TypeParser {
 }
 
 export namespace ReflectionTypeParser {
+  export interface Data {
+    /**
+     * The reflection of this reflection type.
+     * @since 5.0.0
+     */
+    reflection: JSONOutput.DeclarationReflection | null;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Reflection;
 

--- a/src/lib/structures/type-parsers/RestTypeParser.ts
+++ b/src/lib/structures/type-parsers/RestTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class RestTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -17,8 +24,12 @@ export class RestTypeParser implements TypeParser {
    */
   public readonly type: TypeParser;
 
-  public constructor(type: TypeParser) {
+  public constructor(data: RestTypeParser.Data, project: ProjectParser) {
+    const { type } = data;
+
     this.type = type;
+
+    this.project = project;
   }
 
   /**
@@ -54,6 +65,14 @@ export class RestTypeParser implements TypeParser {
 }
 
 export namespace RestTypeParser {
+  export interface Data {
+    /**
+     * The type of this rest type.
+     * @since 5.0.0
+     */
+    type: TypeParser;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Rest;
 

--- a/src/lib/structures/type-parsers/TemplateLiteralTypeParser.ts
+++ b/src/lib/structures/type-parsers/TemplateLiteralTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class TemplateLiteralTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -23,9 +30,13 @@ export class TemplateLiteralTypeParser implements TypeParser {
    */
   public readonly tail: TemplateLiteralTypeParser.Tail[];
 
-  public constructor(head: string, tail: TemplateLiteralTypeParser.Tail[]) {
+  public constructor(data: TemplateLiteralTypeParser.Data, project: ProjectParser) {
+    const { head, tail } = data;
+
     this.head = head;
     this.tail = tail;
+
+    this.project = project;
   }
 
   /**
@@ -62,6 +73,20 @@ export class TemplateLiteralTypeParser implements TypeParser {
 }
 
 export namespace TemplateLiteralTypeParser {
+  export interface Data {
+    /**
+     * The head of this template literal type.
+     * @since 5.0.0
+     */
+    head: string;
+
+    /**
+     * The tail of this template literal type.
+     * @since 5.0.0
+     */
+    tail: Tail[];
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.TemplateLiteral;
 

--- a/src/lib/structures/type-parsers/TupleTypeParser.ts
+++ b/src/lib/structures/type-parsers/TupleTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class TupleTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -17,8 +24,12 @@ export class TupleTypeParser implements TypeParser {
    */
   public readonly types: TypeParser[];
 
-  public constructor(types: TypeParser[]) {
+  public constructor(data: TupleTypeParser.Data, project: ProjectParser) {
+    const { types } = data;
+
     this.types = types;
+
+    this.project = project;
   }
 
   /**
@@ -54,6 +65,14 @@ export class TupleTypeParser implements TypeParser {
 }
 
 export namespace TupleTypeParser {
+  export interface Data {
+    /**
+     * The types of this tuple type.
+     * @since 5.0.0
+     */
+    types: TypeParser[];
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Tuple;
 

--- a/src/lib/structures/type-parsers/TypeOperatorTypeParser.ts
+++ b/src/lib/structures/type-parsers/TypeOperatorTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class TypeOperatorTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -23,9 +30,13 @@ export class TypeOperatorTypeParser implements TypeParser {
    */
   public readonly type: TypeParser;
 
-  public constructor(operator: TypeOperatorTypeParser.Operator, type: TypeParser) {
+  public constructor(data: TypeOperatorTypeParser.Data, project: ProjectParser) {
+    const { operator, type } = data;
+
     this.operator = operator;
     this.type = type;
+
+    this.project = project;
   }
 
   /**
@@ -62,6 +73,20 @@ export class TypeOperatorTypeParser implements TypeParser {
 }
 
 export namespace TypeOperatorTypeParser {
+  export interface Data {
+    /**
+     * The operator of this type operator type.
+     * @since 5.0.0
+     */
+    operator: Operator;
+
+    /**
+     * The type of this type operator type.
+     * @since 5.0.0
+     */
+    type: TypeParser;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.TypeOperator;
 

--- a/src/lib/structures/type-parsers/UnionTypeParser.ts
+++ b/src/lib/structures/type-parsers/UnionTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class UnionTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -17,8 +24,12 @@ export class UnionTypeParser implements TypeParser {
    */
   public readonly types: TypeParser[];
 
-  public constructor(types: TypeParser[]) {
+  public constructor(data: UnionTypeParser.Data, project: ProjectParser) {
+    const { types } = data;
+
     this.types = types;
+
+    this.project = project;
   }
 
   /**
@@ -54,6 +65,14 @@ export class UnionTypeParser implements TypeParser {
 }
 
 export namespace UnionTypeParser {
+  export interface Data {
+    /**
+     * The types of this union type in a JSON compatible format.
+     * @since 5.0.0
+     */
+    types: TypeParser[];
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Union;
 

--- a/src/lib/structures/type-parsers/UnknownTypeParser.ts
+++ b/src/lib/structures/type-parsers/UnknownTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -5,6 +6,12 @@ import { TypeParser } from './TypeParser';
  * @since 1.0.0
  */
 export class UnknownTypeParser implements TypeParser {
+  /**
+   * The project parser this parser belongs to.
+   * @since 5.0.0
+   */
+  public readonly project: ProjectParser;
+
   /**
    * The kind of type this parser is for.
    * @since 1.0.0
@@ -17,8 +24,12 @@ export class UnknownTypeParser implements TypeParser {
    */
   public readonly name: string;
 
-  public constructor(name: string) {
+  public constructor(data: UnknownTypeParser.Data, project: ProjectParser) {
+    const { name } = data;
+
     this.name = name;
+
+    this.project = project;
   }
 
   /**
@@ -54,6 +65,14 @@ export class UnknownTypeParser implements TypeParser {
 }
 
 export namespace UnknownTypeParser {
+  export interface Data {
+    /**
+     * The name of this unknown type.
+     * @since 5.0.0
+     */
+    name: string;
+  }
+
   export interface JSON extends TypeParser.JSON {
     kind: TypeParser.Kind.Unknown;
 


### PR DESCRIPTION
## Commit Body

```
BREAKING CHANGE: The constructor of `ArrayTypeParser` now takes 2 parameters of `ArrayTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `ConditionalTypeParser` now takes 2 parameters of `ConditionalTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `IndexedAccessTypeParser` now takes 2 parameters of `IndexedAccessTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `InferredTypeParser` now takes 2 parameters of `InferredTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `IntersectionTypeParser` now takes 2 parameters of `IntersectionTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `IntrinsicTypeParser` now takes 2 parameters of `IntrinsicTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `LiteralTypeParser` now takes 2 parameters of `LiteralTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `MappedTypeParser` now takes 2 parameters of `MappedTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `NamedTupleMemberTypeParser` now takes 2 parameters of `NamedTupleMemberTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `OptionalTypeParser` now takes 2 parameters of `OptionalTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `PredicateTypeParser` now takes 2 parameters of `PredicateTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `QueryTypeParser` now takes 2 parameters of `QueryTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `ReferenceTypeParser` now takes 2 parameters of `ReferenceTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `ReflectionTypeParser` now takes 2 parameters of `ReflectionTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `RestTypeParser` now takes 2 parameters of `RestTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `TemplateLiteralTypeParser` now takes 2 parameters of `TemplateLiteralTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `TupleTypeParser` now takes 2 parameters of `TupleTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `TypeOperatorTypeParser` now takes 2 parameters of `TypeOperatorTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `UnionTypeParser` now takes 2 parameters of `UnionTypeParser.Data` and `ProjectParser`
BREAKING CHANGE: The constructor of `UnknownTypeParser` now takes 2 parameters of `UnknownTypeParser.Data` and `ProjectParser`
```