### PR TITLE
feat(TypeParser): add `project` parameter to `toString()`

### DIFF
--- a/src/lib/structures/type-parsers/ArrayTypeParser.ts
+++ b/src/lib/structures/type-parsers/ArrayTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -38,19 +39,22 @@ export class ArrayTypeParser implements TypeParser {
   /**
    * Converts this parser to a string.
    * @since 1.0.0
+   * @param project The project to convert this parser to a string.
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return ArrayTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return ArrayTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: ArrayTypeParser): string {
+  public static formatToString(options: TypeParser.FormatToStringOptions<ArrayTypeParser>): string {
+    const { parser } = options;
+
     return `${TypeParser.wrap(parser.type, TypeParser.BindingPowers[TypeParser.Kind.Array])}[]`;
   }
 }

--- a/src/lib/structures/type-parsers/ConditionalTypeParser.ts
+++ b/src/lib/structures/type-parsers/ConditionalTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -64,21 +65,22 @@ export class ConditionalTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return ConditionalTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return ConditionalTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: ConditionalTypeParser): string {
-    return `${TypeParser.wrap(
-      parser.checkType,
-      TypeParser.BindingPowers[TypeParser.Kind.Conditional]
-    )} extends ${parser.extendsType.toString()} ? ${parser.trueType.toString()} : ${parser.falseType.toString()}`;
+  public static formatToString(options: TypeParser.FormatToStringOptions<ConditionalTypeParser>): string {
+    const { parser, project } = options;
+
+    return `${TypeParser.wrap(parser.checkType, TypeParser.BindingPowers[TypeParser.Kind.Conditional])} extends ${parser.extendsType.toString(
+      project
+    )} ? ${parser.trueType.toString(project)} : ${parser.falseType.toString(project)}`;
   }
 }
 

--- a/src/lib/structures/type-parsers/IndexedAccessTypeParser.ts
+++ b/src/lib/structures/type-parsers/IndexedAccessTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -48,18 +49,20 @@ export class IndexedAccessTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return IndexedAccessTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return IndexedAccessTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: IndexedAccessTypeParser): string {
-    return `${parser.objectType.toString()}[${parser.indexType.toString()}]`;
+  public static formatToString(options: TypeParser.FormatToStringOptions<IndexedAccessTypeParser>): string {
+    const { parser, project } = options;
+
+    return `${parser.objectType.toString(project)}[${parser.indexType.toString(project)}]`;
   }
 }
 

--- a/src/lib/structures/type-parsers/InferredTypeParser.ts
+++ b/src/lib/structures/type-parsers/InferredTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -40,17 +41,19 @@ export class InferredTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return InferredTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return InferredTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: InferredTypeParser): string {
+  public static formatToString(options: TypeParser.FormatToStringOptions<InferredTypeParser>): string {
+    const { parser } = options;
+
     return `infer ${parser.type}`;
   }
 }

--- a/src/lib/structures/type-parsers/IntersectionTypeParser.ts
+++ b/src/lib/structures/type-parsers/IntersectionTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -40,17 +41,19 @@ export class IntersectionTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return IntersectionTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return IntersectionTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: IntersectionTypeParser): string {
+  public static formatToString(options: TypeParser.FormatToStringOptions<IntersectionTypeParser>): string {
+    const { parser } = options;
+
     return parser.types.map((type) => TypeParser.wrap(type, TypeParser.BindingPowers[TypeParser.Kind.Intersection])).join(' & ');
   }
 }

--- a/src/lib/structures/type-parsers/IntrinsicTypeParser.ts
+++ b/src/lib/structures/type-parsers/IntrinsicTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -40,17 +41,19 @@ export class IntrinsicTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return IntrinsicTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return IntrinsicTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: IntrinsicTypeParser): string {
+  public static formatToString(options: TypeParser.FormatToStringOptions<IntrinsicTypeParser>): string {
+    const { parser } = options;
+
     return parser.type;
   }
 }

--- a/src/lib/structures/type-parsers/LiteralTypeParser.ts
+++ b/src/lib/structures/type-parsers/LiteralTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -40,17 +41,19 @@ export class LiteralTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return LiteralTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return LiteralTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: LiteralTypeParser): string {
+  public static formatToString(options: TypeParser.FormatToStringOptions<LiteralTypeParser>): string {
+    const { parser } = options;
+
     return parser.value;
   }
 }

--- a/src/lib/structures/type-parsers/MappedTypeParser.ts
+++ b/src/lib/structures/type-parsers/MappedTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -80,23 +81,24 @@ export class MappedTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return MappedTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return MappedTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: MappedTypeParser): string {
+  public static formatToString(options: TypeParser.FormatToStringOptions<MappedTypeParser>): string {
+    const { parser, project } = options;
     const readonly =
       parser.readonly === MappedTypeParser.Modifier.Add ? 'readonly' : parser.readonly === MappedTypeParser.Modifier.Remove ? '-readonly' : '';
 
     const optional = parser.optional === MappedTypeParser.Modifier.Add ? '?' : parser.optional === MappedTypeParser.Modifier.Remove ? '-?' : '';
 
-    return `{ ${readonly}[${parser.parameter} in ${parser.parameterType.toString()}]${optional}: ${parser.templateType.toString()} }`;
+    return `{ ${readonly}[${parser.parameter} in ${parser.parameterType.toString(project)}]${optional}: ${parser.templateType.toString(project)} }`;
   }
 }
 

--- a/src/lib/structures/type-parsers/NamedTupleMemberTypeParser.ts
+++ b/src/lib/structures/type-parsers/NamedTupleMemberTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -56,18 +57,20 @@ export class NamedTupleMemberTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return NamedTupleMemberTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return NamedTupleMemberTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: NamedTupleMemberTypeParser): string {
-    return `${parser.name}${parser.optional ? '?' : ''}: ${parser.type.toString()}`;
+  public static formatToString(options: TypeParser.FormatToStringOptions<NamedTupleMemberTypeParser>): string {
+    const { parser, project } = options;
+
+    return `${parser.name}${parser.optional ? '?' : ''}: ${parser.type.toString(project)}`;
   }
 }
 

--- a/src/lib/structures/type-parsers/OptionalTypeParser.ts
+++ b/src/lib/structures/type-parsers/OptionalTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -40,17 +41,19 @@ export class OptionalTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return OptionalTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return OptionalTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: OptionalTypeParser): string {
+  public static formatToString(options: TypeParser.FormatToStringOptions<OptionalTypeParser>): string {
+    const { parser } = options;
+
     return `${TypeParser.wrap(parser.type, TypeParser.BindingPowers[TypeParser.Kind.Optional])}?`;
   }
 }

--- a/src/lib/structures/type-parsers/PredicateTypeParser.ts
+++ b/src/lib/structures/type-parsers/PredicateTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -57,18 +58,20 @@ export class PredicateTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return PredicateTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return PredicateTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: PredicateTypeParser): string {
-    return parser.asserts ? `asserts ${parser.name}` : `${parser.name} is ${parser.type!.toString()}`;
+  public static formatToString(options: TypeParser.FormatToStringOptions<PredicateTypeParser>): string {
+    const { parser, project } = options;
+
+    return parser.asserts ? `asserts ${parser.name}` : `${parser.name} is ${parser.type!.toString(project)}`;
   }
 }
 

--- a/src/lib/structures/type-parsers/QueryTypeParser.ts
+++ b/src/lib/structures/type-parsers/QueryTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import type { ReferenceTypeParser } from './ReferenceTypeParser';
 import { TypeParser } from './TypeParser';
 
@@ -41,18 +42,20 @@ export class QueryTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return QueryTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return QueryTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: QueryTypeParser): string {
-    return `typeof ${parser.query.toString()}`;
+  public static formatToString(options: TypeParser.FormatToStringOptions<QueryTypeParser>): string {
+    const { parser, project } = options;
+
+    return `typeof ${parser.query.toString(project)}`;
   }
 }
 

--- a/src/lib/structures/type-parsers/ReferenceTypeParser.ts
+++ b/src/lib/structures/type-parsers/ReferenceTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -71,20 +72,22 @@ export class ReferenceTypeParser implements TypeParser {
   /**
    * Converts this parser to a string.
    * @since 1.0.0
+   * @param project The project to convert this parser to a string.
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return ReferenceTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return ReferenceTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: ReferenceTypeParser): string {
-    const typeArguments = parser.typeArguments.length > 0 ? `<${parser.typeArguments.map((type) => type.toString()).join(', ')}>` : '';
+  public static formatToString(options: TypeParser.FormatToStringOptions<ReferenceTypeParser>): string {
+    const { parser, project } = options;
+    const typeArguments = parser.typeArguments.length > 0 ? `<${parser.typeArguments.map((type) => type.toString(project)).join(', ')}>` : '';
 
     return `${parser.packageName ? `${parser.packageName}.` : ''}${parser.name}${typeArguments}`;
   }

--- a/src/lib/structures/type-parsers/ReflectionTypeParser.ts
+++ b/src/lib/structures/type-parsers/ReflectionTypeParser.ts
@@ -1,4 +1,5 @@
 import type { JSONOutput } from 'typedoc';
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -41,17 +42,19 @@ export class ReflectionTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return ReflectionTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return ReflectionTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: ReflectionTypeParser): string {
+  public static formatToString(options: TypeParser.FormatToStringOptions<ReflectionTypeParser>): string {
+    const { parser } = options;
+
     return !parser.reflection?.children && parser.reflection?.signatures ? 'Function' : 'Object';
   }
 }

--- a/src/lib/structures/type-parsers/RestTypeParser.ts
+++ b/src/lib/structures/type-parsers/RestTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -40,17 +41,19 @@ export class RestTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return RestTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return RestTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: RestTypeParser): string {
+  public static formatToString(options: TypeParser.FormatToStringOptions<RestTypeParser>): string {
+    const { parser } = options;
+
     return `...${TypeParser.wrap(parser.type, TypeParser.BindingPowers[TypeParser.Kind.Rest])}`;
   }
 }

--- a/src/lib/structures/type-parsers/TemplateLiteralTypeParser.ts
+++ b/src/lib/structures/type-parsers/TemplateLiteralTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -48,18 +49,20 @@ export class TemplateLiteralTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return TemplateLiteralTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return TemplateLiteralTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: TemplateLiteralTypeParser): string {
-    return `\`${parser.head}${parser.tail.map((tail) => `\${${tail.type.toString()}}${tail.text}`).join('')}\``;
+  public static formatToString(options: TypeParser.FormatToStringOptions<TemplateLiteralTypeParser>): string {
+    const { parser, project } = options;
+
+    return `\`${parser.head}${parser.tail.map((tail) => `\${${tail.type.toString(project)}}${tail.text}`).join('')}\``;
   }
 }
 

--- a/src/lib/structures/type-parsers/TupleTypeParser.ts
+++ b/src/lib/structures/type-parsers/TupleTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -40,18 +41,20 @@ export class TupleTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return TupleTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return TupleTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: TupleTypeParser): string {
-    return `[${parser.types.map((type) => type.toString()).join(', ')}]`;
+  public static formatToString(options: TypeParser.FormatToStringOptions<TupleTypeParser>): string {
+    const { parser, project } = options;
+
+    return `[${parser.types.map((type) => type.toString(project)).join(', ')}]`;
   }
 }
 

--- a/src/lib/structures/type-parsers/TypeOperatorTypeParser.ts
+++ b/src/lib/structures/type-parsers/TypeOperatorTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -48,18 +49,20 @@ export class TypeOperatorTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return TypeOperatorTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return TypeOperatorTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: TypeOperatorTypeParser): string {
-    return `${parser.operator} ${parser.type.toString()}`;
+  public static formatToString(options: TypeParser.FormatToStringOptions<TypeOperatorTypeParser>): string {
+    const { parser, project } = options;
+
+    return `${parser.operator} ${parser.type.toString(project)}`;
   }
 }
 

--- a/src/lib/structures/type-parsers/TypeParser.ts
+++ b/src/lib/structures/type-parsers/TypeParser.ts
@@ -1,5 +1,6 @@
 import type { JSONOutput } from 'typedoc';
 import type { NamedTupleMemberType } from 'typedoc/dist/lib/serialization/schema';
+import type { ProjectParser } from '../ProjectParser';
 import { ArrayTypeParser } from './ArrayTypeParser';
 import { ConditionalTypeParser } from './ConditionalTypeParser';
 import { IndexedAccessTypeParser } from './IndexedAccessTypeParser';
@@ -40,9 +41,10 @@ export interface TypeParser {
 
   /**
    * The method to convert this type parser to a string.
+   * @param project The optional project parser to use.
    * @since 1.0.0
    */
-  toString(): string;
+  toString(project?: ProjectParser): string;
 }
 
 export namespace TypeParser {
@@ -50,7 +52,6 @@ export namespace TypeParser {
    * Generates a new {@link TypeParser} instance from the given data.
    * @since 1.0.0
    * @param type The type to generate the parser from.
-   * @param  The  this parser belongs to.
    * @returns The generated parser.
    */
   export function generateFromTypeDoc(
@@ -482,5 +483,23 @@ export namespace TypeParser {
      * @since 1.0.0
      */
     kind: Kind;
+  }
+
+  /**
+   * The options for the static `*TypeParser.formatToString()` methods.
+   * @since 7.0.0
+   */
+  export interface FormatToStringOptions<P extends TypeParser> {
+    /**
+     * The type parser to format.
+     * @since 7.0.0
+     */
+    parser: P;
+
+    /**
+     * The project this type parser belongs to.
+     * @since 7.0.0
+     */
+    project?: ProjectParser;
   }
 }

--- a/src/lib/structures/type-parsers/UnionTypeParser.ts
+++ b/src/lib/structures/type-parsers/UnionTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -40,17 +41,19 @@ export class UnionTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return UnionTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return UnionTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: UnionTypeParser): string {
+  public static formatToString(options: TypeParser.FormatToStringOptions<UnionTypeParser>): string {
+    const { parser } = options;
+
     return parser.types.map((type) => TypeParser.wrap(type, TypeParser.BindingPowers[TypeParser.Kind.Union])).join(' | ');
   }
 }

--- a/src/lib/structures/type-parsers/UnknownTypeParser.ts
+++ b/src/lib/structures/type-parsers/UnknownTypeParser.ts
@@ -1,3 +1,4 @@
+import type { ProjectParser } from '../ProjectParser';
 import { TypeParser } from './TypeParser';
 
 /**
@@ -40,17 +41,19 @@ export class UnknownTypeParser implements TypeParser {
    * @since 1.0.0
    * @returns The string representation of this parser.
    */
-  public toString(): string {
-    return UnknownTypeParser.formatToString(this);
+  public toString(project?: ProjectParser): string {
+    return UnknownTypeParser.formatToString({ parser: this, project });
   }
 
   /**
    * Formats this type parser to a string.
    * @since 4.0.0
-   * @param parser The parser to format.
+   * @param options The options to format this type parser to a string.
    * @returns The string representation of this parser.
    */
-  public static formatToString(parser: UnknownTypeParser): string {
+  public static formatToString(options: TypeParser.FormatToStringOptions<UnknownTypeParser>): string {
+    const { parser } = options;
+
     return parser.name;
   }
 }


### PR DESCRIPTION
## Commit Body

```
BREAKING CHANGE: `*TypeParser.formatToString()` now accepts a single parameter of `TypeParser.FormatToStringOptions<*TypeParser>`.
```