### PR TITLE
feat!: update Node to v20

### DIFF
--- a/.github/workflows/auto-deprecate.yml
+++ b/.github/workflows/auto-deprecate.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - name: Checkout Project
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Use Node.js v16
+      - name: Use Node.js v20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
           registry-url: https://registry.yarnpkg.com
       - name: Install Dependencies

--- a/.github/workflows/continuous-delivery.yml
+++ b/.github/workflows/continuous-delivery.yml
@@ -26,10 +26,10 @@ jobs:
           ref: ${{ github.event.inputs.branch || 'main' }}
       - name: Add TypeScript Problem Matcher
         run: echo "::add-matcher::.github/problemMatchers/tsc.json"
-      - name: Use Node.js v16
+      - name: Use Node.js v20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
           registry-url: https://registry.yarnpkg.com
       - name: Install Dependencies

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -15,10 +15,10 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Add ESLint Problem Matcher
         run: echo "::add-matcher::.github/problemMatchers/eslint.json"
-      - name: Use Node.js v16
+      - name: Use Node.js v20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
           registry-url: https://registry.yarnpkg.com
       - name: Install Dependencies
@@ -34,10 +34,10 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
       - name: Add TypeScript Problem Matcher
         run: echo "::add-matcher::.github/problemMatchers/tsc.json"
-      - name: Use Node.js v16
+      - name: Use Node.js v20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
           registry-url: https://registry.yarnpkg.com
       - name: Install Dependencies
@@ -52,10 +52,10 @@ jobs:
     steps:
       - name: Checkout Project
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Use Node.js v16
+      - name: Use Node.js v20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
           registry-url: https://registry.yarnpkg.com/
       - name: Install Dependencies
@@ -69,10 +69,10 @@ jobs:
     steps:
       - name: Checkout Project
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Use Node.js v16
+      - name: Use Node.js v20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
           registry-url: https://registry.yarnpkg.com
       - name: Install Dependencies

--- a/.github/workflows/deprecate-on-merge.yml
+++ b/.github/workflows/deprecate-on-merge.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - name: Checkout Project
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Use Node.js v16
+      - name: Use Node.js v20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
           registry-url: https://registry.yarnpkg.com
       - name: Install Dependencies

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -27,10 +27,10 @@ jobs:
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
         with:
           ref: ${{ github.event.inputs.ref || '' }}
-      - name: Use Node.js v16
+      - name: Use Node.js v20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
           registry-url: https://registry.yarnpkg.com/
       - name: Install Dependencies
@@ -60,10 +60,10 @@ jobs:
     steps:
       - name: Checkout Project
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
-      - name: Use Node.js v16
+      - name: Use Node.js v20
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4
         with:
-          node-version: 16
+          node-version: 20
           cache: yarn
           registry-url: https://registry.yarnpkg.com/
       - name: Install Dependencies

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "!dist/*.tsbuildinfo"
   ],
   "engines": {
-    "node": ">=18.17.0",
+    "node": ">=20",
     "npm": ">=6"
   },
   "keywords": [],


### PR DESCRIPTION
This pull request update Node to v20, dropping support for v18 makes this a breaking change.

- [x] Configure TypeScript Configuration to properly compile for Node v20

### Commit Body
```
feat: update Node to v20

BREAKING CHANGE: Drop support for Node.js v16 and v18
```